### PR TITLE
Network bugfixes

### DIFF
--- a/Client/NetworkClient.cpp
+++ b/Client/NetworkClient.cpp
@@ -147,7 +147,7 @@ void NetworkClient::socketReadHandler()
 		{
 			int recvResult = recv(
 					_socket,
-					lengthBuf,
+					lengthBuf + bytesRead,
 					sizeof(uint32_t),
 					0);
 			if (recvResult > 0)
@@ -348,6 +348,23 @@ void NetworkClient::sendEvents(std::vector<std::shared_ptr<GameEvent>> events)
         {
             _eventQueue->push(event);
         }
+    }
+}
+
+
+void NetworkClient::sendEvent(std::shared_ptr<GameEvent> event)
+{
+    // Check to see if connection is active, throw exception if it is not
+    std::unique_lock<std::mutex> socketLock(_socketMutex);
+    if (_socket == INVALID_SOCKET)
+    {
+        socketLock.unlock();
+        throw(std::runtime_error("Not connected to a server"));
+    }
+    else
+    {
+        socketLock.unlock();
+		_eventQueue->push(event);
     }
 }
 

--- a/Client/NetworkClient.hpp
+++ b/Client/NetworkClient.hpp
@@ -75,6 +75,11 @@ public:
 	void sendEvents(std::vector<std::shared_ptr<GameEvent>> events);
 
 	/*
+	** Same as above, except with only a single event.
+	*/
+	void sendEvent(std::shared_ptr<GameEvent> event);
+
+	/*
     ** API: Receive updates from the server. Synchronous for the calling
     ** thread; asynchronous with respect to the network.
     **

--- a/Server/GameServer.cpp
+++ b/Server/GameServer.cpp
@@ -30,7 +30,6 @@ void GameServer::start()
 
 void GameServer::update()
 {
-    int counter = 0;
     while (true)
     {
         auto timerStart = std::chrono::steady_clock::now();

--- a/Server/NetworkServer.cpp
+++ b/Server/NetworkServer.cpp
@@ -444,8 +444,6 @@ void NetworkServer::socketWriteHandler()
                         (int)session.writeBuf.size(),
                         0);
 
-					std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
                     // If no error, shrink buffer
                     if (sendResult > 0)
                     {
@@ -465,8 +463,6 @@ void NetworkServer::socketWriteHandler()
 						break;
                     }
                 }
-
-				Logger::getInstance()->debug("Finished sending 1 object");
             }
         }
         free(databuf);

--- a/Server/NetworkServer.cpp
+++ b/Server/NetworkServer.cpp
@@ -150,7 +150,7 @@ void NetworkServer::connectionListener(
 			{
 				IdGenerator::getInstance()->getNextId(), // create a new player id
 				tempSock, // socket
-				std::vector<char>(RECV_BUFSIZE), // read buffer
+				(char*)calloc(1, RECV_BUFSIZE), // read buffer
 				false, // is reading
 				0, // length (bytes to read)
 				0, // bytes read
@@ -177,6 +177,7 @@ void NetworkServer::connectionListener(
 				else if (!sendResult || sendResult == SOCKET_ERROR)
 				{
                     Logger::getInstance()->error("Failed to send player ID to new client");
+					free(clientState.readBuf);
 					closesocket(tempSock);
 					tempSock = INVALID_SOCKET;
 					continue;
@@ -193,6 +194,7 @@ void NetworkServer::connectionListener(
                 Logger::getInstance()->fatal(
                         "Failed to set socket as non-blocking. Error code: " +
                         std::to_string(res));
+				free(clientState.readBuf);
 				closesocket(tempSock);
 				WSACleanup();
 				exit(1);
@@ -270,56 +272,66 @@ void NetworkServer::socketReadHandler()
             // Iterate over sessions
             for (auto& pair : _sessions)
             {
-                SocketState session = pair.second;
+                SocketState * session = &(pair.second);
 
                 // If in the read set, recv and push to buffer
-                if (FD_ISSET(session.socket, &readSet))
+                if (FD_ISSET(session->socket, &readSet))
                 {
                     int recvResult = recv(
-                            session.socket,
-                            session.readBuf.data() + session.bytesRead,
-                            (int)session.readBuf.size(),
+                            session->socket,
+                            session->readBuf + session->bytesRead,
+                            RECV_BUFSIZE - session->bytesRead,
                             0);
 
                     // If zero, we had a clean disconnect, so mark as dead
                     if (!recvResult)
                     {
                         // Mark socket as dead
-                        sessionsToKill.push(session.playerId);
+                        sessionsToKill.push(session->playerId);
                     }
                     else if (recvResult != SOCKET_ERROR)
                     {
-                        session.bytesRead += recvResult;
+                        session->bytesRead += recvResult;
 
-                        // If we're not in reading mode and received at least
-                        // four bytes, store length and go into reading mode.
-                        if (!session.isReading && session.bytesRead >= sizeof(uint32_t))
-                        {
-                            // Get the first four bytes and store as length
-                            memcpy(&(session.length), session.readBuf.data(), sizeof(uint32_t));
-                            session.isReading = true;
-                        }
+						while ((session->isReading && (session->length + sizeof(uint32_t)) <= session->bytesRead) ||
+								(!session->isReading && session->bytesRead >= sizeof(uint32_t)))
+						{
+							// If we're not in reading mode and received at least
+							// four bytes, store length and go into reading mode.
+							if (!session->isReading && session->bytesRead >= sizeof(uint32_t))
+							{
+								// Get the first four bytes and store as length
+								memcpy(&(session->length), session->readBuf, sizeof(uint32_t));
+								session->isReading = true;
+							}
 
-                        // Deserialize object
-                        if (session.isReading && session.bytesRead >= session.length)
-                        {
-                            ss.write(session.readBuf.data() + sizeof(uint32_t), session.length);
-                            cereal::BinaryInputArchive iarchive(ss);
-                            std::shared_ptr<GameEvent> eventPtr;
-                            iarchive(eventPtr);
+							// Deserialize object
+							if (session->isReading && session->bytesRead >= (session->length + sizeof(uint32_t)))
+							{
+								ss.write(session->readBuf + sizeof(uint32_t), session->length);
+								cereal::BinaryInputArchive iarchive(ss);
+								std::shared_ptr<GameEvent> eventPtr;
+								iarchive(eventPtr);
 
-                            // Enforce correct player ID
-                            eventPtr->playerId = session.playerId;
+								// Enforce correct player ID
+								eventPtr->playerId = session->playerId;
 
-                            // Lock and add to queue
-                            std::unique_lock<std::mutex> eventLock(_eventMutex);
-                            _eventQueue->push(eventPtr);
-                            eventLock.unlock();
+								// Lock and add to queue
+								std::unique_lock<std::mutex> eventLock(_eventMutex);
+								_eventQueue->push(eventPtr);
+								eventLock.unlock();
 
-                            // reset state
-                            session.bytesRead -= (session.length + sizeof(uint32_t));
-                            session.isReading = false;
-                        }
+								// reset state
+								session->bytesRead -= (session->length + sizeof(uint32_t));
+								session->isReading = false;
+
+								// Effectively "remove" length and item from buffer
+								memmove(
+										session->readBuf,
+										session->readBuf + session->length + sizeof(uint32_t), 
+										RECV_BUFSIZE - (session->length + sizeof(uint32_t)));
+							}
+						}
                     }
                     else
                     {
@@ -328,26 +340,26 @@ void NetworkServer::socketReadHandler()
                         {
                             Logger::getInstance()->info(
                                     "Encountered error while reading socket for player " +
-                                    std::to_string(session.playerId) + " with code " +
+                                    std::to_string(session->playerId) + " with code " +
                                     std::to_string(WSAGetLastError()));
 
-                            sessionsToKill.push(session.playerId);
+                            sessionsToKill.push(session->playerId);
                         }
                     }
                 }
 
                 // If in the exception set, mark session as dead.
-                if (FD_ISSET(session.socket, &exceptSet))
+                if (FD_ISSET(session->socket, &exceptSet))
                 {
                     // Mark socket as dead 
                     if (WSAGetLastError() != WSAEWOULDBLOCK)
                     {
                         Logger::getInstance()->info(
                                 "Encountered error while reading socket for player " +
-                                std::to_string(session.playerId) + " with code " +
+                                std::to_string(session->playerId) + " with code " +
                                 std::to_string(WSAGetLastError()));
 
-                        sessionsToKill.push(session.playerId);
+                        sessionsToKill.push(session->playerId);
                     }
                 }
             }
@@ -366,6 +378,9 @@ void NetworkServer::socketReadHandler()
 
 void NetworkServer::socketWriteHandler()
 {
+
+    // List of dead sockets to kill
+    std::queue<uint32_t> sessionsToKill = std::queue<uint32_t>();
 
     while (true)
     {
@@ -429,6 +444,8 @@ void NetworkServer::socketWriteHandler()
                         (int)session.writeBuf.size(),
                         0);
 
+					std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
                     // If no error, shrink buffer
                     if (sendResult > 0)
                     {
@@ -443,11 +460,24 @@ void NetworkServer::socketWriteHandler()
                                 "Encountered error while writing socket for player " +
                                 std::to_string(session.playerId) + " with code " +
                                 std::to_string(WSAGetLastError()));
+
+						sessionsToKill.push(session.playerId);
+						break;
                     }
                 }
+
+				Logger::getInstance()->debug("Finished sending 1 object");
             }
         }
         free(databuf);
+
+		// Kill sessions marked for death
+		lock.unlock();
+		while (!sessionsToKill.empty())
+		{
+			closePlayerSession(sessionsToKill.front());
+			sessionsToKill.pop();
+		}
     }
     return;
 }
@@ -482,6 +512,7 @@ void NetworkServer::closePlayerSession(uint32_t playerId)
                 "Closing session for player " +
                 std::to_string(playerId));
 
+		free(result->second.readBuf);
         closesocket(result->second.socket);
         _sessions.erase(result);
     }
@@ -520,10 +551,16 @@ void NetworkServer::sendUpdates(std::vector<std::shared_ptr<BaseState>> updates)
 {
     for (auto& update : updates)
     {
-        // We are sending to all players, so use 0 as playerId
-        std::pair<uint32_t, std::shared_ptr<BaseState>> updatePair = std::make_pair(0, update);
-        _updateQueue->push(updatePair);
+		sendUpdate(update);
     }
+}
+
+
+void NetworkServer::sendUpdate(std::shared_ptr<BaseState> update)
+{
+	// We are sending to all players, so use 0 as playerId
+	std::pair<uint32_t, std::shared_ptr<BaseState>> updatePair = std::make_pair(0, update);
+	_updateQueue->push(updatePair);
 }
 
 
@@ -531,8 +568,14 @@ void NetworkServer::sendUpdates(std::vector<std::shared_ptr<BaseState>> updates,
 {
     for (auto& update : updates)
     {
-        // We are sending to just one player
-        std::pair<uint32_t, std::shared_ptr<BaseState>> updatePair = std::make_pair(playerId, update);
-        _updateQueue->push(updatePair);
+		sendUpdate(update, playerId);
     }
+}
+
+
+void NetworkServer::sendUpdate(std::shared_ptr<BaseState> update, uint32_t playerId)
+{
+	// We are sending to just one player
+	std::pair<uint32_t, std::shared_ptr<BaseState>> updatePair = std::make_pair(playerId, update);
+	_updateQueue->push(updatePair);
 }

--- a/Server/NetworkServer.hpp
+++ b/Server/NetworkServer.hpp
@@ -87,6 +87,11 @@ public:
 	*/
 	void sendUpdates(std::vector<std::shared_ptr<BaseState>> updates);
 
+	/*
+	** Same as above, except it sends a single update only.
+	*/
+	void sendUpdate(std::shared_ptr<BaseState> update);
+
     /*
     ** API: Send updates to a particular client. Use this if updates need to be
     ** sent only to a certain player (at login, for example). See the function
@@ -97,6 +102,12 @@ public:
     ** set to the value that is passed to this function.
     **/
     void sendUpdates(std::vector<std::shared_ptr<BaseState>> updates, uint32_t playerId);
+
+	/*
+	** Same as above, except it sends a single update only.
+	*/
+	void sendUpdate(std::shared_ptr<BaseState> update, uint32_t playerId);
+
 
 private:
 	/*
@@ -141,7 +152,7 @@ private:
 		SOCKET socket;
 
         // Read stuff
-		std::vector<char> readBuf;
+		char* readBuf;
 		bool isReading;
 		uint32_t length;
 		uint32_t bytesRead;


### PR DESCRIPTION
Realized that reads on the server side weren't handled properly, for a multitude of reasons.
- The "session" variable was stored on the stack. Thus any updates to it were not applied to the original SocketSession. bytesRead, for example, would get zeroed out every loop. So I switched it to a pointer.
- Switched readBuf from vector to char*. This wasn't strictly necessary but we weren't using the vector features for anything
- Added a while loop after each recv() in socketReadHandler(). This ensures that as many objects are deserialized as possible per recv() call. The logic is definitely messier than before but so far it's been working much better. If you have suggestions for improvement, please let me know!

Other fixes:
- Client recv() while loop for length didn't account for bytesRead. This is a very rare case and only happens when the number of bytes received is less than 4
- If sockets encounter an error during socketWriteHandler() on the server, they will now be added to a queue and killed at the end of the loop. We didn't have this at first because we were worried about race conditions (and put session destruction logic in socketReadHandler() only), but these should be impossible due to the locks we have in place.

Misc:
- Added sendEvent() and sendUpdate() functions to send only one item instead of a whole vector.