### PR TITLE
Automatic Shader Uniform Registration

### DIFF
--- a/Client/Application.cpp
+++ b/Client/Application.cpp
@@ -48,13 +48,13 @@ Application::~Application() {
 }
 
 void Application::Setup() {
-  // Background color
+  // OpenGL Graphics Setup
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glEnable(GL_DEPTH_TEST);
   glDepthFunc(GL_LEQUAL);
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  //glEnable(GL_CULL_FACE);
+  glEnable(GL_CULL_FACE);
 
   // Initialize pointers
   _testShader = std::make_unique<Shader>();
@@ -70,22 +70,16 @@ void Application::Setup() {
   _testShader->LoadFromFile(GL_VERTEX_SHADER, "./Resources/Shaders/pano.vert");
   _testShader->LoadFromFile(GL_FRAGMENT_SHADER, "./Resources/Shaders/pano.frag");
   _testShader->CreateProgram();
-  _testShader->RegisterUniform("rgbTexture");
 
   // quad pass through shader
   _quadShader->LoadFromFile(GL_VERTEX_SHADER, "./Resources/Shaders/quad.vert");
   _quadShader->LoadFromFile(GL_FRAGMENT_SHADER, "./Resources/Shaders/quad.frag");
   _quadShader->CreateProgram();
-  _quadShader->RegisterUniform("rgbTexture");
 
   // Basic model shader
   _cubeShader->LoadFromFile(GL_VERTEX_SHADER, "./Resources/Shaders/basiclight.vert");
   _cubeShader->LoadFromFile(GL_FRAGMENT_SHADER, "./Resources/Shaders/basiclight.frag");
   _cubeShader->CreateProgram();
-  _cubeShader->RegisterUniformList({ "u_projection", "u_view", "u_model",
-    "u_light.position", "u_light.ambient", "u_light.diffuse", "u_light.specular", "u_light.constant", "u_light.constant", "u_light.linear", "u_light.quadratic",
-    "u_material.diffuse", "u_material.specular", "u_material.shininess"
-    });
 
   // Create cube model
   _cube = std::make_unique<Model>("./Resources/Models/simpleobject2.obj");
@@ -208,7 +202,7 @@ void Application::Reset() {
 }
 
 void Application::StaticError(int error, const char* description) {
-  std::cerr << description << std::endl;
+  Logger::getInstance()->error(std::string(description));
 }
 
 void Application::StaticResize(GLFWwindow* window, int x, int y) {

--- a/Client/Resources/Shaders/basiclight.frag
+++ b/Client/Resources/Shaders/basiclight.frag
@@ -65,8 +65,8 @@ void main(void)
   vec3 normal = normalize(pass_normal);
   vec3 viewDir = normalize(u_viewPos - pass_fragPos);
   
-  //vec3 resultCol = CalcPointLight(u_light, normal, pass_fragPos, viewDir);
-  vec3 resultCol = texture(u_material.diffuse, pass_uv).rgb;
+  vec3 resultCol = CalcPointLight(u_light, normal, pass_fragPos, viewDir);
+  //vec3 resultCol = texture(u_material.diffuse, pass_uv).rgb;
   
   out_color = vec4(resultCol, 1.0f);
 }

--- a/Client/Resources/Shaders/basiclight.vert
+++ b/Client/Resources/Shaders/basiclight.vert
@@ -4,9 +4,9 @@ layout(location = 0) in vec3 in_position;
 layout(location = 1) in vec3 in_normal;
 layout(location = 2) in vec2 in_uv;
 
-uniform mat4 u_projection = mat4(1);
-uniform mat4 u_view = mat4(1);
-uniform mat4 u_model = mat4(1);
+uniform mat4 u_projection;
+uniform mat4 u_view;
+uniform mat4 u_model;
 
 out vec3 pass_fragPos;
 out vec3 pass_normal;

--- a/Client/Shader.hpp
+++ b/Client/Shader.hpp
@@ -25,13 +25,6 @@ public:
 
   void Use() const;
 
-  /**
-   * @brief Finds and stores the specified uniform location of the shader.
-   */
-  void RegisterUniform(const char* uniform);
-
-  void RegisterUniformList(std::initializer_list<const char*> uniforms);
-
   void set_uniform(const char *uniform, GLint value);
   void set_uniform(const char *uniform, GLuint value);
 
@@ -56,7 +49,17 @@ private:
   GLuint _fragment_shader;
 
   // Map of uniform names to locations
-  std::unordered_map<std::string, GLuint> _uniforms;
+  std::unordered_map<std::string, GLint> _uniforms;
+
+  /**
+   * \brief Finds and stores the specified uniform variable's location in the shader program.
+   */
+  void RegisterUniform(const char* uniform);
+
+  /**
+   * \brief Automatically finds all uniform variables for the shader program.
+   */
+  void AutoRegisterUniforms();
 };
 
 #endif /* SHADER_HPP */


### PR DESCRIPTION
Made shader infinitely easier to use by automatically detecting all available shader uniforms. One caveat: shader compiler optimizes variables out if they are not necessary, so attempting to set uniform variables that were not registered because of optimization will cause and error. Luckily, it won't break anything, but the logger will be filled with endless error messages saying an unregistered uniform was attempted to be set.