### PR TITLE
Network bugfixes, TCP_NODELAY on clients

### DIFF
--- a/Client/NetworkClient.cpp
+++ b/Client/NetworkClient.cpp
@@ -66,6 +66,10 @@ uint32_t NetworkClient::connect(std::string address, std::string port)
             throw std::runtime_error("Socket creation failed with error: " + WSAGetLastError());
 		}
 
+		// Disable nagle's algorithm
+		char one = 1;
+		setsockopt(clientSock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
 		// Connect to server.
 		iResult = ::connect(clientSock, ptr->ai_addr, (int)ptr->ai_addrlen);
 		if (iResult == SOCKET_ERROR) 
@@ -92,8 +96,8 @@ uint32_t NetworkClient::connect(std::string address, std::string port)
 		{
 			int recvResult = recv(
 					_socket,
-					playerId,
-					sizeof(playerId),
+					playerId + bytesRead,
+					sizeof(playerId) - bytesRead,
 					0);
 
 			// We got data
@@ -148,7 +152,7 @@ void NetworkClient::socketReadHandler()
 			int recvResult = recv(
 					_socket,
 					lengthBuf + bytesRead,
-					sizeof(uint32_t),
+					sizeof(uint32_t) - bytesRead,
 					0);
 			if (recvResult > 0)
 			{

--- a/Server/NetworkServer.cpp
+++ b/Server/NetworkServer.cpp
@@ -144,8 +144,8 @@ void NetworkServer::connectionListener(
         // Otherwise create a player session for the new socket
 		if (tempSock != INVALID_SOCKET)
 		{
-			char value = 1;
-			setsockopt(tempSock, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value));
+			char one = 1;
+			setsockopt(tempSock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 			SocketState clientState =
 			{
 				IdGenerator::getInstance()->getNextId(), // create a new player id
@@ -166,8 +166,8 @@ void NetworkServer::connectionListener(
 			{
 				int sendResult = send(
 						tempSock,
-						(char*)(&(clientState.playerId)),
-						sizeof(uint32_t),
+						(char*)(&(clientState.playerId)) + bytesSent,
+						sizeof(uint32_t) - bytesSent,
 						0);
 
 				if (sendResult > 0)


### PR DESCRIPTION
The send() and recv() calls for transferring playerId's were not properly integrated into their respective while loops. It is unlikely that this would ever be an issue, but it's good to make sure everything works in all cases.

Also set the TCP_NODELAY option on the client sockets, which disables Nagle's algorithm and sends bytes from the buffer as soon as possible. This should speed up client event sending to some extent. Note that we already had the TCP_NODELAY option set on the server side.