### PR TITLE
Animation state synchronization

### DIFF
--- a/Client/CDogEntity.hpp
+++ b/Client/CDogEntity.hpp
@@ -23,9 +23,13 @@ public:
 		// Set dog-specific state variables
 		auto currentState = std::static_pointer_cast<DogState>(_state);
 		auto newState = std::static_pointer_cast<DogState>(state);
+		
+		// Animation
+		currentState->currentAnimation = newState->currentAnimation;
+		_playerModel->animatedMesh->_takeIndex = newState->currentAnimation;
 
+		// Dog attributes and items
 		currentState->runStamina = newState->runStamina;
-		// TODO
 	}
 };
 

--- a/Client/CHumanEntity.hpp
+++ b/Client/CHumanEntity.hpp
@@ -24,7 +24,11 @@ public:
 		auto currentState = std::static_pointer_cast<HumanState>(_state);
 		auto newState = std::static_pointer_cast<HumanState>(state);
 
-		// TODO
+		// Animation
+		currentState->currentAnimation = newState->currentAnimation;
+		_playerModel->animatedMesh->_takeIndex = newState->currentAnimation;
+
+		// Human attributes and items
 	}
 };
 

--- a/Client/CPlayerEntity.hpp
+++ b/Client/CPlayerEntity.hpp
@@ -92,6 +92,7 @@ protected:
             _playerModel->animatedMesh->_takeIndex %= _playerModel->animatedMesh->takeCount();
         });
 
+		/*
         GuiManager::getInstance().getFormHelper("Form helper")->addGroup("Cycle Animation");
         GuiManager::getInstance().getFormHelper("Form helper")->addButton("Next", [&]() {
             _playerModel->animatedMesh->_takeIndex += 1;
@@ -104,6 +105,7 @@ protected:
         GuiManager::getInstance().setDirty();
 
         // TODO: determine which animation gets played
+		*/
         _playerModel->animatedMesh->_takeIndex = 0;
 
         // Call init to let Animation precache uniform location

--- a/Client/CPlayerEntity.hpp
+++ b/Client/CPlayerEntity.hpp
@@ -85,14 +85,8 @@ protected:
     void initAnimation(std::string modelPath) {
         // Read in an animated Mesh
         _playerModel = std::make_unique<Animation>(modelPath);
-
-        InputManager::getInstance().getKey(85)->onPress([this]()
-        {
-            _playerModel->animatedMesh->_takeIndex += 1;
-            _playerModel->animatedMesh->_takeIndex %= _playerModel->animatedMesh->takeCount();
-        });
-
-		// Ensuring index is non-garbage value
+		
+        // Ensuring index is non-garbage value
         _playerModel->animatedMesh->_takeIndex = 0;
 
         // Call init to let Animation precache uniform location

--- a/Client/CPlayerEntity.hpp
+++ b/Client/CPlayerEntity.hpp
@@ -92,20 +92,7 @@ protected:
             _playerModel->animatedMesh->_takeIndex %= _playerModel->animatedMesh->takeCount();
         });
 
-		/*
-        GuiManager::getInstance().getFormHelper("Form helper")->addGroup("Cycle Animation");
-        GuiManager::getInstance().getFormHelper("Form helper")->addButton("Next", [&]() {
-            _playerModel->animatedMesh->_takeIndex += 1;
-            _playerModel->animatedMesh->_takeIndex %= _playerModel->animatedMesh->takeCount();
-            _currentAnim = _playerModel->animatedMesh->getCurrentAnimName();
-        })->setTooltip("Testing a much longer tooltip, that will wrap around to new lines multiple times.");
-
-        GuiManager::getInstance().getFormHelper("Form helper")->addVariable("Current Animation", _currentAnim);
-
-        GuiManager::getInstance().setDirty();
-
-        // TODO: determine which animation gets played
-		*/
+		// Ensuring index is non-garbage value
         _playerModel->animatedMesh->_takeIndex = 0;
 
         // Call init to let Animation precache uniform location

--- a/Server/SDogEntity.hpp
+++ b/Server/SDogEntity.hpp
@@ -29,12 +29,37 @@ public:
 
 		// Dog-specific stuff
 		auto dogState = std::static_pointer_cast<DogState>(_state);
+		dogState->currentAnimation = ANIMATION_DOG_IDLE;
 		dogState->runStamina = 10;
 	};
 
 	~SDogEntity() {};
 
 	bool isCaught = false;
+
+	void update(std::vector<std::shared_ptr<GameEvent>> events) override
+	{
+		auto dogState = std::static_pointer_cast<DogState>(_state);
+
+		// Save old position
+		glm::vec3 oldPos = _state->pos;
+
+		// Update and check for changes
+		SPlayerEntity::update(events);
+
+		// Set running/not running based on position
+		if (_state->pos != oldPos)
+		{
+			dogState->currentAnimation = ANIMATION_DOG_RUNNING;
+		}
+		else if (dogState->currentAnimation != ANIMATION_DOG_IDLE)
+		{
+			dogState->currentAnimation = ANIMATION_DOG_IDLE;
+			hasChanged = true;
+		}
+
+		// TODO: catching animation
+	}
 
 	void handleCollision(std::shared_ptr<SBaseEntity> entity) override
 	{

--- a/Server/SHumanEntity.hpp
+++ b/Server/SHumanEntity.hpp
@@ -26,9 +26,34 @@ public:
 
 		// Human-specific stuff
 		auto humanState = std::static_pointer_cast<HumanState>(_state);
+		humanState->currentAnimation = ANIMATION_HUMAN_IDLE;
 	};
 
 	~SHumanEntity() {};
+
+	void update(std::vector<std::shared_ptr<GameEvent>> events) override
+	{
+		auto humanState = std::static_pointer_cast<HumanState>(_state);
+
+		// Save old position
+		glm::vec3 oldPos = _state->pos;
+
+		// Update and check for changes
+		SPlayerEntity::update(events);
+
+		// Set running/not running based on position
+		if (_state->pos != oldPos)
+		{
+			humanState->currentAnimation = ANIMATION_HUMAN_RUNNING;
+		}
+		else if (humanState->currentAnimation != ANIMATION_HUMAN_IDLE)
+		{
+			humanState->currentAnimation = ANIMATION_HUMAN_IDLE;
+			hasChanged = true;
+		}
+
+		// TODO: catching animation
+	}
 
 	void handleCollision(std::shared_ptr<SBaseEntity> entity)
 	{

--- a/Shared/Common.hpp
+++ b/Shared/Common.hpp
@@ -40,3 +40,20 @@ enum ColliderType
 	COLLIDER_AABB,
 	COLLIDER_CAPSULE
 };
+
+// Ensure animations are in the same order as their corresponding text files!
+
+// Animations for humans
+enum HumanAnimation
+{
+	ANIMATION_HUMAN_IDLE, // Index 0
+	ANIMATION_HUMAN_RUNNING, // Index 1
+	ANIMATION_HUMAN_CATCHING // Index 2
+};
+
+// Animations for dogs
+enum DogAnimation
+{
+	ANIMATION_DOG_IDLE, // Index 0
+	ANIMATION_DOG_RUNNING // Index 1
+};

--- a/Shared/DogState.hpp
+++ b/Shared/DogState.hpp
@@ -6,6 +6,7 @@
 
 struct DogState : PlayerState
 {
+	DogAnimation currentAnimation;
 	int runStamina;
 
 	template<class Archive>
@@ -13,6 +14,7 @@ struct DogState : PlayerState
 	{
 		archive(
 			cereal::base_class<PlayerState>(this),
+			currentAnimation,
 			runStamina);
 	}
 };

--- a/Shared/HumanState.hpp
+++ b/Shared/HumanState.hpp
@@ -8,11 +8,14 @@
 struct HumanState : public PlayerState
 {
 	// TODO: Human-specific state
+	HumanAnimation currentAnimation;
 
 	template<class Archive>
 	void serialize(Archive & archive)
 	{
-		archive(cereal::base_class<PlayerState>(this));
+		archive(
+			cereal::base_class<PlayerState>(this),
+			currentAnimation);
 	}
 };
 


### PR DESCRIPTION
Animations now set on server side and synced with clients. The net handling hasn't been implemented; I'm not sure if there's a way to just play an animation once -- if so, that's probably what we want to do for the net. We'd also have to add in a lunging component on the server side, which might be a tad tricky. So, for now, just running and idle animations.

Note also that animations may be interrupted; the running animation might be halfway through when it gets changed suddenly to an idle animation. There is no smooth transition, though honestly I don't think this will matter too much.