### PR TITLE
Player movement w/ glm::vec2

### DIFF
--- a/Client/Application.cpp
+++ b/Client/Application.cpp
@@ -42,7 +42,7 @@ Application::Application(const char* windowTitle, int argc, char** argv) {
     joinEvent->playerName = "Player" + std::to_string(playerId);
     _networkClient->sendEvent(joinEvent);
 
-    _localPlayer = std::make_unique<LocalPlayer>(playerId, _networkClient.get());
+    _localPlayer = std::make_unique<LocalPlayer>(playerId, _networkClient);
   }
   catch (std::runtime_error e)
   {

--- a/Client/Application.cpp
+++ b/Client/Application.cpp
@@ -42,7 +42,7 @@ Application::Application(const char* windowTitle, int argc, char** argv) {
     joinEvent->playerName = "Player" + std::to_string(playerId);
     _networkClient->sendEvent(joinEvent);
 
-    _localPlayer = std::make_unique<LocalPlayer>(playerId, _networkClient);
+    _localPlayer = std::make_unique<LocalPlayer>(playerId, _networkClient.get());
   }
   catch (std::runtime_error e)
   {

--- a/Client/Application.cpp
+++ b/Client/Application.cpp
@@ -275,6 +275,9 @@ void Application::Update()
   {
     // Disconnected from the server
   }
+
+  InputManager::getInstance().update();
+
   if (_localPlayer) {
       _localPlayer->update();
   }
@@ -283,7 +286,6 @@ void Application::Update()
   AudioManager::getInstance().update();
 
     
-  InputManager::getInstance().update();
   _camera->Update();
   _point_light->update();
 }

--- a/Client/LocalPlayer.cpp
+++ b/Client/LocalPlayer.cpp
@@ -3,7 +3,7 @@
 #include "Shared/GameEvent.hpp"
 #include "EntityManager.hpp"
 
-LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
+LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const& networkClient) {
 
     _playerId = playerId;
 
@@ -11,6 +11,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
     InputManager::getInstance().getKey(GLFW_KEY_W)->onRepeat([&]
     {
 		_moveKeysPressed = true;
+		_stopped = false;
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -28,6 +29,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
     InputManager::getInstance().getKey(GLFW_KEY_S)->onRepeat([&]
     {
 		_moveKeysPressed = true;
+		_stopped = false;
 		auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -45,6 +47,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
     InputManager::getInstance().getKey(GLFW_KEY_A)->onRepeat([&]
     {
 		_moveKeysPressed = true;
+		_stopped = false;
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -62,6 +65,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
     InputManager::getInstance().getKey(GLFW_KEY_D)->onRepeat([&]
     {
 		_moveKeysPressed = true;
+		_stopped = false;
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -79,7 +83,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
 	_camera->set_pitch(_pitch);
     _offset = glm::normalize(glm::vec3(0.0f, 0.5f, 0.5f));
 
-	_networkClient = networkClient;
+	_networkClient = networkClient.get();
 
 	_moveKeysPressed = false;
 	_stopped = true;
@@ -106,10 +110,6 @@ void LocalPlayer::update() {
 		event->playerId = _playerId;
 		event->type = EVENT_PLAYER_STOP;
 		_networkClient->sendEvent(event);
-	}
-	else if (_moveKeysPressed)
-	{
-		_stopped = false;
 	}
 
 	_moveKeysPressed = false;

--- a/Client/LocalPlayer.cpp
+++ b/Client/LocalPlayer.cpp
@@ -12,7 +12,8 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     {
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
-        event->type = EVENT_PLAYER_MOVE_FORWARD;
+        event->type = EVENT_PLAYER_MOVE;
+		event->direction = glm::vec2(0, -1);
 
         // Try sending the update
         try {
@@ -27,7 +28,8 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     {
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
-        event->type = EVENT_PLAYER_MOVE_BACKWARD;
+        event->type = EVENT_PLAYER_MOVE;
+		event->direction = glm::vec2(0, 1);
 
         // Try sending the update
         try {
@@ -42,7 +44,8 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     {
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
-        event->type = EVENT_PLAYER_MOVE_LEFT;
+        event->type = EVENT_PLAYER_MOVE;
+		event->direction = glm::vec2(-1, 0);
 
         // Try sending the update
         try {
@@ -57,7 +60,8 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     {
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
-        event->type = EVENT_PLAYER_MOVE_RIGHT;
+        event->type = EVENT_PLAYER_MOVE;
+		event->direction = glm::vec2(1, 0);
 
         // Try sending the update
         try {

--- a/Client/LocalPlayer.cpp
+++ b/Client/LocalPlayer.cpp
@@ -3,13 +3,14 @@
 #include "Shared/GameEvent.hpp"
 #include "EntityManager.hpp"
 
-LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const& networkClient) {
+LocalPlayer::LocalPlayer(uint32_t playerId, NetworkClient* networkClient) {
 
     _playerId = playerId;
 
     // Player move forward event
     InputManager::getInstance().getKey(GLFW_KEY_W)->onRepeat([&]
     {
+		_moveKeysPressed = true;
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -26,7 +27,8 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     // Player move backward event
     InputManager::getInstance().getKey(GLFW_KEY_S)->onRepeat([&]
     {
-        auto event = std::make_shared<GameEvent>();
+		_moveKeysPressed = true;
+		auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
 		event->direction = glm::vec2(0, 1);
@@ -42,6 +44,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     // Player move left event
     InputManager::getInstance().getKey(GLFW_KEY_A)->onRepeat([&]
     {
+		_moveKeysPressed = true;
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -58,6 +61,7 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     // Player move right event
     InputManager::getInstance().getKey(GLFW_KEY_D)->onRepeat([&]
     {
+		_moveKeysPressed = true;
         auto event = std::make_shared<GameEvent>();
         event->playerId = _playerId;
         event->type = EVENT_PLAYER_MOVE;
@@ -74,6 +78,11 @@ LocalPlayer::LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const
     _camera = std::make_unique<Camera>();
 	_camera->set_pitch(_pitch);
     _offset = glm::normalize(glm::vec3(0.0f, 0.5f, 0.5f));
+
+	_networkClient = networkClient;
+
+	_moveKeysPressed = false;
+	_stopped = true;
 }
 
 void LocalPlayer::update() {
@@ -88,6 +97,22 @@ void LocalPlayer::update() {
     }
     _camera->set_position(_playerEntity->getState()->pos + _distance * _offset);
     _camera->Update();
+
+	// Stop events for the server
+	if (!_stopped && !_moveKeysPressed)
+	{
+		_stopped = true;
+		auto event = std::make_shared<GameEvent>();
+		event->playerId = _playerId;
+		event->type = EVENT_PLAYER_STOP;
+		_networkClient->sendEvent(event);
+	}
+	else if (_moveKeysPressed)
+	{
+		_stopped = false;
+	}
+
+	_moveKeysPressed = false;
 }
 
 std::unique_ptr<Camera> const& LocalPlayer::getCamera() {

--- a/Client/LocalPlayer.cpp
+++ b/Client/LocalPlayer.cpp
@@ -127,6 +127,23 @@ void LocalPlayer::inputReadHandler()
 	{
 		if (pad->isConnected())
 		{
+			auto dir = pad->getLS();
+			if (dir != glm::vec2(0))
+			{
+				// Invert z
+				dir.y = -(dir.y);
+
+				// Send event
+				auto event = std::make_shared<GameEvent>();
+				event->type = EVENT_PLAYER_MOVE;
+				event->playerId = _playerId;
+				event->direction = dir;
+				_networkClient->sendEvent(event);
+
+				_stopped = false;
+				_moveKeysPressed = true;
+			}
+
 			if (pad->isKeyDown(GamePad_Button_DPAD_LEFT)) {
 				InputManager::getInstance().fire(GLFW_KEY_A, KeyState::Press);
 			};

--- a/Client/LocalPlayer.hpp
+++ b/Client/LocalPlayer.hpp
@@ -28,7 +28,7 @@ public:
      * \param playerId(uint32_t) Entity id of local player
      * \param networkClient(std::unique_ptr<NetworkClient> const&) networkClient for sending events
      */
-    LocalPlayer(uint32_t playerId, NetworkClient* networkClient);
+    LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const& networkClient);
 
     /**
      * \brief Update camera based on player entity.

--- a/Client/LocalPlayer.hpp
+++ b/Client/LocalPlayer.hpp
@@ -13,10 +13,13 @@ private:
 
     std::unique_ptr<Camera> _camera;
     std::shared_ptr<CPlayerEntity> _playerEntity;
+	NetworkClient* _networkClient;
 
 	glm::vec3 _offset;
 	float _pitch = -45.0f;
 	float _distance = 14.0f;
+
+	bool _moveKeysPressed, _stopped;
 
 public:
 
@@ -25,7 +28,7 @@ public:
      * \param playerId(uint32_t) Entity id of local player
      * \param networkClient(std::unique_ptr<NetworkClient> const&) networkClient for sending events
      */
-    LocalPlayer(uint32_t playerId, std::unique_ptr<NetworkClient> const& networkClient);
+    LocalPlayer(uint32_t playerId, NetworkClient* networkClient);
 
     /**
      * \brief Update camera based on player entity.

--- a/Server/SDogEntity.hpp
+++ b/Server/SDogEntity.hpp
@@ -59,6 +59,8 @@ public:
 			if (event->type == EVENT_PLAYER_STOP)
 			{
 				dogState->currentAnimation = ANIMATION_DOG_IDLE;
+				hasChanged = true;
+				break;
 			}
 		}
 

--- a/Server/SDogEntity.hpp
+++ b/Server/SDogEntity.hpp
@@ -52,10 +52,14 @@ public:
 		{
 			dogState->currentAnimation = ANIMATION_DOG_RUNNING;
 		}
-		else if (dogState->currentAnimation != ANIMATION_DOG_IDLE)
+
+		// Check for stop event
+		for (auto& event : events)
 		{
-			dogState->currentAnimation = ANIMATION_DOG_IDLE;
-			hasChanged = true;
+			if (event->type == EVENT_PLAYER_STOP)
+			{
+				dogState->currentAnimation = ANIMATION_DOG_IDLE;
+			}
 		}
 
 		// TODO: catching animation

--- a/Server/SHumanEntity.hpp
+++ b/Server/SHumanEntity.hpp
@@ -46,10 +46,14 @@ public:
 		{
 			humanState->currentAnimation = ANIMATION_HUMAN_RUNNING;
 		}
-		else if (humanState->currentAnimation != ANIMATION_HUMAN_IDLE)
+
+		// Check for stop event
+		for (auto& event : events)
 		{
-			humanState->currentAnimation = ANIMATION_HUMAN_IDLE;
-			hasChanged = true;
+			if (event->type == EVENT_PLAYER_STOP)
+			{
+				humanState->currentAnimation = ANIMATION_HUMAN_IDLE;
+			}
 		}
 
 		// TODO: catching animation

--- a/Server/SHumanEntity.hpp
+++ b/Server/SHumanEntity.hpp
@@ -53,6 +53,8 @@ public:
 			if (event->type == EVENT_PLAYER_STOP)
 			{
 				humanState->currentAnimation = ANIMATION_HUMAN_IDLE;
+				hasChanged = true;
+				break;
 			}
 		}
 

--- a/Server/SPlayerEntity.hpp
+++ b/Server/SPlayerEntity.hpp
@@ -5,6 +5,9 @@
 #include "CapsuleCollider.hpp"
 #include "Shared\PlayerState.hpp"
 
+// Amount of leway when comparing floats
+const float FP_EPSILON = 0.00001f;
+
 class SPlayerEntity : public SBaseEntity
 {
 public:
@@ -57,16 +60,36 @@ public:
 			// If any events left, process them
 			if (events.size())
 			{
+				// Movement
+				std::vector<std::shared_ptr<GameEvent>> movementEvents;
+				std::copy_if(events.begin(), events.end(), std::back_inserter(movementEvents), [&](std::shared_ptr<GameEvent> i)
+				{
+					return i->type == EVENT_PLAYER_MOVE;
+				});
+
+				// Sort by vector
+				std::sort(movementEvents.begin(), movementEvents.end(),
+					[](const std::shared_ptr<GameEvent> & a, const std::shared_ptr<GameEvent> & b) -> bool
+					{
+						if (std::abs(a->direction.x - b->direction.x) < FP_EPSILON)
+							return a->direction.x < b->direction.x;
+						else
+							return a->direction.y < b->direction.y;
+					});
+
+				// Remove duplicate vectors
+				movementEvents.erase(std::unique(movementEvents.begin(), movementEvents.end(),
+					[](const std::shared_ptr<GameEvent> & a, const std::shared_ptr<GameEvent> & b) -> bool
+					{
+						return a->direction == b->direction;
+					}), movementEvents.end());
+
 				// Overall direction of player; take average of all direction vectors
 				glm::vec3 dir = glm::vec3(0);
 
-				for (auto& event : events)
+				for (auto& moveEvent : movementEvents)
 				{
-					// We assume player direction change happens before movement
-					if (event->type == EVENT_PLAYER_MOVE)
-					{
-						dir += glm::vec3(event->direction.x, 0, event->direction.y);
-					}
+					dir += glm::vec3(moveEvent->direction.x, 0, moveEvent->direction.y);
 				}
 
 				// Update forward vector with unit direction only if it was modified
@@ -74,6 +97,7 @@ public:
 				{
 					hasChanged = true;
 					_state->forward = dir / glm::length(dir);
+
 
 					// Move player by (direction * velocity) / ticks_per_sec
 					auto oldPos = _state->pos;

--- a/Server/SPlayerEntity.hpp
+++ b/Server/SPlayerEntity.hpp
@@ -54,37 +54,18 @@ public:
 		// Only change attributes of this object if not static
 		if (!_state->isStatic)
 		{
-			// Remove duplicate events (events are already sorted)
-			events.erase(std::unique(events.begin(), events.end(),
-				[](const std::shared_ptr<GameEvent> & a, const std::shared_ptr<GameEvent> & b) -> bool
-				{
-					return a->type == b->type;
-				}), events.end());
-
 			// If any events left, process them
 			if (events.size())
 			{
-				// Overall direction of player
+				// Overall direction of player; take average of all direction vectors
 				glm::vec3 dir = glm::vec3(0);
 
 				for (auto& event : events)
 				{
-					switch (event->type)
+					// We assume player direction change happens before movement
+					if (event->type == EVENT_PLAYER_MOVE)
 					{
-					case EVENT_PLAYER_MOVE_FORWARD:
-						dir += glm::vec3(0, 0, -1);
-						break;
-					case EVENT_PLAYER_MOVE_BACKWARD:
-						dir += glm::vec3(0, 0, 1);
-						break;
-					case EVENT_PLAYER_MOVE_LEFT:
-						dir += glm::vec3(-1, 0, 0);
-						break;
-					case EVENT_PLAYER_MOVE_RIGHT:
-						dir += glm::vec3(1, 0, 0);
-						break;
-					default:
-						break;
+						dir += glm::vec3(event->direction.x, 0, event->direction.y);
 					}
 				}
 

--- a/Shared/BaseState.hpp
+++ b/Shared/BaseState.hpp
@@ -6,7 +6,7 @@
 
 #include "Shared/Common.hpp"	// GameEntity type enum
 
-// Allow Cereal serialization of GLM vectors
+// Allow Cereal serialization of GLM 3-item vectors
 namespace cereal
 {
 	template<class Archive>

--- a/Shared/GameEvent.hpp
+++ b/Shared/GameEvent.hpp
@@ -1,8 +1,19 @@
 #pragma once
 
+#include <glm/glm.hpp>
 #include <stdint.h>
 #include <string>
 #include "Shared/Logger.hpp"
+
+// Allow Cereal serialization of GLM 2-item vectors
+namespace cereal
+{
+	template<class Archive>
+	void serialize(Archive & archive, glm::vec2 &v)
+	{
+        archive(v.x, v.y);
+	}
+}
 
 /*
 ** A few enums outlining the different types of events that could be triggered
@@ -14,10 +25,8 @@ enum EventType
 {
     EVENT_PLAYER_JOIN,
     EVENT_PLAYER_LEAVE, // Created only by the server
-    EVENT_PLAYER_MOVE_FORWARD,
-    EVENT_PLAYER_MOVE_BACKWARD,
-    EVENT_PLAYER_MOVE_LEFT,
-    EVENT_PLAYER_MOVE_RIGHT
+	EVENT_PLAYER_MOVE,	// Movement vector for player
+	EVENT_PLAYER_STOP
     // TODO: more event types here
 };
 
@@ -30,13 +39,18 @@ struct GameEvent
     EventType type;
     uint32_t playerId; // Not used for EVENT_PLAYER_JOIN
     std::string playerName; // Used only for EVENT_PLAYER_JOIN
+	glm::vec2 direction;	// Used only for PLAYER_TURN and PLAYER_MOVE
     //TODO: add more elements as necessary
 
     // Serialization for Cereal
     template<class Archive>
     void serialize(Archive & archive)
     {
-        archive(type, playerId, playerName);
+        archive(
+			type,
+			playerId,
+			playerName,
+			direction);
     }
 
 	void print()


### PR DESCRIPTION
*** Do not merge until #20 is merged into game-logic ***

Refactored GameEvents so movement is sent by the client as a glm::vec2 direction. Using Xbox left stick for movement as well. We may need to refactor this if we also plan to send player orientation as well (on camera move, for example), but the change would be relatively straightforward.