### PR TITLE
Music mute & hotkeys, pitch increase @30s

### DIFF
--- a/Client/Application.cpp
+++ b/Client/Application.cpp
@@ -469,12 +469,17 @@ void Application::Update()
 
 			// Increase speed of bgm if less than 30 seconds left
 			auto bgmSource = AudioManager::getInstance().getAudioSource("bgm");
-			if (!_inLobby && !gameState->gameOver && gameState->millisecondsLeft < 30000)
+			if (!_musicSpeedup && !_inLobby && !gameState->gameOver &&
+				gameState->millisecondsLeft < 30000)
 			{
-				bgmSource->_channel->setPitch(1.5f);
+				// Start song from the beginning
+				_musicSpeedup = true;
+				bgmSource->_channel->setPosition(0, FMOD_TIMEUNIT_MS);
+				bgmSource->_channel->setPitch(1.3f);
 			}
-			else
+			else if (gameState->gameOver)
 			{
+				_musicSpeedup = false;
 				bgmSource->_channel->setPitch(1.0f);
 			}
 

--- a/Client/Application.cpp
+++ b/Client/Application.cpp
@@ -137,10 +137,6 @@ void Application::Setup() {
 		joinEvent->playerName = playerName;
 		_networkClient->sendEvent(joinEvent);
 
-
-		// Reset hotkeys first
-	    InputManager::getInstance().reset();
-
 		// Create local player
 		_localPlayer = std::make_unique<LocalPlayer>(playerId, _networkClient);
 
@@ -222,9 +218,6 @@ void Application::Setup() {
 	_bgm->init("Resources/Sounds/bgm1.mp3");
 	_bgm->setVolume(0.05f);
 	_bgm->play(true);
-
-	// Register global keys
-	registerGlobalKeys();
 }
 
 void Application::Cleanup() {
@@ -495,6 +488,7 @@ void Application::Update()
 	  // show connection screen
 	  _localPlayer = nullptr;
 	  _networkClient->closeConnection();
+	  InputManager::getInstance().reset();
 	  EntityManager::getInstance().clearAll();
 	  AudioManager::getInstance().reset();
 	  ColliderManager::getInstance().clear();

--- a/Client/Application.hpp
+++ b/Client/Application.hpp
@@ -121,6 +121,9 @@ private:
 
   // Background music source
   AudioSource* _bgm = nullptr;
+  
+  // Whether the music is playing fast
+  bool _musicSpeedup = false;
 
   // Test Lights
   std::unique_ptr<DirectionalLight> _dir_light;

--- a/Client/GUIManager.cpp
+++ b/Client/GUIManager.cpp
@@ -202,6 +202,14 @@ void GuiManager::registerDisconnectCallback(const std::function<void()> f) {
 	_disconnectButton->setCallback(f);
 }
 
+void GuiManager::toggleMute() {
+	_muteButton->callback()();
+}
+
+void GuiManager::toggleMusicMute() {
+	_muteMusicButton->callback()();
+}
+
 std::string GuiManager::getPlayerName() {
 	return _playerNameBox->value();
 }
@@ -673,6 +681,23 @@ void GuiManager::initControlMenu() {
 		else
 		{
 			_muteButton->setCaption("Unmute All");
+		}
+	});
+
+	_muteMusicButton = new nanogui::Button(controlsWidget, "Mute Music");
+	_muteMusicButton->setCallback([&]()
+	{
+		auto musicChannel = AudioManager::getInstance().getAudioSource("bgm")->_channel;
+		bool isPaused;
+		musicChannel->getPaused(&isPaused);
+		musicChannel->setPaused(!isPaused);
+		if (isPaused)
+		{
+			_muteMusicButton->setCaption("Mute Music");
+		}
+		else
+		{
+			_muteMusicButton->setCaption("Unmute Music");
 		}
 	});
 

--- a/Client/GUIManager.hpp
+++ b/Client/GUIManager.hpp
@@ -64,6 +64,10 @@ public:
 	void registerControllerCallback(const std::function<void(GamePadIndex)> f);
 	void registerDisconnectCallback(const std::function<void()> f);
 
+	// Callbacks on mute buttons
+	void toggleMute();
+	void toggleMusicMute();
+
 	// Text in player name and address boxes
 	std::string getPlayerName();
 	void setPlayerName(std::string val);
@@ -163,6 +167,7 @@ private:
 	// Controls menu
 	nanogui::detail::FormWidget<GamePadIndex, std::integral_constant<bool, true>>* _gamepadSelect;
 	nanogui::Button* _muteButton;
+	nanogui::Button* _muteMusicButton;
 	nanogui::Button* _disconnectButton;
 
 	// Upper HUD

--- a/Client/InputManager.cpp
+++ b/Client/InputManager.cpp
@@ -104,6 +104,7 @@ bool InputManager::isForegroundWindow() const {
 void InputManager::reset() {
 	_lock.lock();
 	_keyList.clear();
+	_onScroll.clear();
 	_lock.unlock();
 }
 


### PR DESCRIPTION
'N' toggles master mute, 'M' toggles music mute. Both buttons are also accessible from the control menu. Pitch of the background music increases by a factor of 1.3 when 30 seconds are left in the game. We probably still need a sound that is played when the game is over.

Also (hopefully) fixed a long-standing bug where scrolling at the beginning of the game would cause a crash. It seems I wasn't properly clearing the onScroll() lambda vector on disconnect.